### PR TITLE
Rebrand site for Academic Culture Enjoyers

### DIFF
--- a/packages/ilmomasiina-components/src/styles/_definitions.scss
+++ b/packages/ilmomasiina-components/src/styles/_definitions.scss
@@ -6,8 +6,8 @@
 // For Bootstrap components, the overrides are made in ilmomasiina-frontend/src/styles/app.scss.
 // If you want to override more colors, you'll also need to add them to the @use there.
 
-$primary: #0a0d10 !default;
-$secondary: #0a0d10 !default;
+$primary: #006994 !default;
+$secondary: #006994 !default;
 $red: #d74949 !default; // further assigned to $danger by Bootstrap
 $green: #319236 !default; // further assigned to $success by Bootstrap
 $text-muted: #888 !default;
@@ -27,7 +27,7 @@ $secondary-background: #f1f1f1 !default;
 $secondary-text-color: #7a7a7a !default;
 
 // If you don't want a header logo, set this to false.
-$header-logo: true !default;
+$header-logo: false !default;
 
 // Import Bootstrap core mixins/variables/functions for use in Ilmomasiina's SCSS.
 

--- a/packages/ilmomasiina-frontend/src/branding.ts
+++ b/packages/ilmomasiina-frontend/src/branding.ts
@@ -8,17 +8,16 @@ export type Branding = {
   loginPlaceholderEmail: string;
 };
 
-// The following strings can be changed here in code, or you can use Docker build args
-// (or env variables) to change them at build time.
+// The following strings can be changed here in code.
 
 const branding: Branding = {
-  headerTitle: BRANDING_HEADER_TITLE_TEXT,
-  headerTitleShort: BRANDING_HEADER_TITLE_TEXT_SHORT,
-  footerGdprText: BRANDING_FOOTER_GDPR_TEXT,
-  footerGdprLink: BRANDING_FOOTER_GDPR_LINK,
-  footerHomeText: BRANDING_FOOTER_HOME_TEXT,
-  footerHomeLink: BRANDING_FOOTER_HOME_LINK,
-  loginPlaceholderEmail: BRANDING_LOGIN_PLACEHOLDER_EMAIL,
+  headerTitle: "Academic Culture Enjoyers",
+  headerTitleShort: "ACE",
+  footerGdprText: "Privacy Policy",
+  footerGdprLink: "https://academicculture.org/privacy",
+  footerHomeText: "Home",
+  footerHomeLink: "https://academicculture.org",
+  loginPlaceholderEmail: "admin@academicculture.org",
 };
 
 export default branding;


### PR DESCRIPTION
## Summary
- switch theme colors to sea blue and hide header logo
- update branding text for Academic Culture Enjoyers
- restore original favicons to avoid shipping new binaries

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Env variable NEW_EDIT_TOKEN_SECRET must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c4e572788324925f36bd35fbff6f