### PR TITLE
Enable Docker image builds on forks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,8 @@
 name: Build & deploy
 
 env:
-  # Change this to upload the built image to your own organization.
-  docker_tag: "ghcr.io/tietokilta/ilmomasiina"
+  # Push images to the container registry for the current repository
+  docker_tag: ghcr.io/${{ github.repository }}
 
   # Change these to customize your build.
   branding_header_title_text: "Tietokillan ilmomasiina"
@@ -53,8 +53,6 @@ jobs:
     permissions:
       packages: write
       contents: read
-    # Change this to your repo name to build automatically on your fork.
-    if: github.repository == 'Tietokilta/ilmomasiina'
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Build Docker images to ghcr.io/<owner>/<repo> for any fork
- Run Docker publish workflow without restricting repository

## Testing
- `npm run lint`
- `npm run typecheck`
- `THIS_IS_A_TEST_DB_AND_CAN_BE_WIPED=1 DB_DIALECT=sqlite npm test` *(fails: Invalid database config: DB_HOST, DB_DATABASE and DB_USER must be set with DB_DIALECT)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8e7b2488324bb4a21d0475b4c51